### PR TITLE
Fix path variable replacement on successive calls

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,13 +24,14 @@ Object.keys(methods).forEach(function(mName) {
     if (arguments.length === 1) callback = parameters;
     if (arguments.length === 2) callback = path;
 
+    var computedPath = m.basePath;
     if (typeof arguments[1] === 'object') {
-      m.path = m.path.replace(/{([^}]*)}/g, function(s, p) {
+      computedPath = m.basePath.replace(/{([^}]*)}/g, function(s, p) {
         return path[p];
       });
     }
 
-    var reqUri = this._uri + m.path;
+    var reqUri = this._uri + computedPath;
 
     if (m.method === 'GET' && parameters) {
       reqUri = reqUri + '?' + serializeObjToUri(parameters);


### PR DESCRIPTION
If I do multiple calls to `getInputExtractors` method, variable
replacement on path is already done and concrete calls have the same
path.

```
api.getInputExtractors({}, {inputId: 'shaid1'});
//http://apiurl/system/inputs/shaid1/extractors

api.getInputExtractors({}, {inputId: 'shaid2'});
//http://apiurl/system/inputs/shaid1/extractors

api.getInputExtractors({}, {inputId: 'shaid3'});
//http://apiurl/system/inputs/shaid1/extractors
```

What do you think ?
