### PR TITLE
Fix Graylog api calls with Content-Type HTTP header

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,8 @@ Object.keys(methods).forEach(function(mName) {
       url: reqUri,
       method: m.method,
       headers: {
-        Accept: 'application/json'
+        Accept: 'application/json',
+        "Content-Type": 'application/json'
       },
       body: (m.method !== 'GET' && parameters) ? parameters : null,
       json: false


### PR DESCRIPTION
When I do `createInputExtractor` calls, I got a `HTTP 415 Unsupported Media Type` error because HTTP call does not contain HTTP Content-Type header.
