### PR TITLE
Added config option for path

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ var api = graylog.connect({
   }, // Optional. Default: null. Basic access authentication
   protocol: 'https', // Optional. Default: 'http'. Connection protocol
   host: 'example.com', // Optional. Default: 'localhost'. API hostname
-  port: '12900' // Optional. Default: '12900'. API port
+  port: '12900', // Optional. Default: '12900'. API port
+  path: '/api', // Optional. Default: ''. API Path
 });
 
 api.searchAbsolute({ // parameters

--- a/index.js
+++ b/index.js
@@ -16,7 +16,8 @@ var Api = function(config) {
   this._auth = (config.basicAuth) ? buildBasicAuthHeader(config.basicAuth) : '';
   this._host = config.host || 'localhost';
   this._port = config.port || '12900';
-  this._uri = this._protocol + '://' + this._host + ':' + this._port;
+  this._path = config.path || '';
+  this._uri = this._protocol + '://' + this._host + ':' + this._port + this._path;
 };
 
 Object.keys(methods).forEach(function(mName) {


### PR DESCRIPTION
From Graylog 2.1, there is a new (and default) way of exposing the API Interface. This is documented here:
http://docs.graylog.org/en/2.1/pages/configuration/web_interface.html#single-or-separate-listeners-for-web-interface-and-rest-api

This PR adds a `path` config option, which allows the user to specify an optional path which will be appended at the end of the uri.