### PR TITLE
Fix url undefined issue which is due to recent refactoring

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,13 @@ function serializeObjToUri(obj) {
 }
 
 var Api = function(config) {
-  this._uri = this.uri;
+  config = config || {}
+  const basicAuthToken = config.basicAuth ?
+    config.basicAuth.username + ':' + config.basicAuth.password + '@' : ''
+
+  this._uri = (config.protocol || 'http') + '://' + basicAuthToken +
+    (config.host || 'localhost') + ':' + (config.port || '12900') +
+    (config.path || '')
 };
 
 Object.keys(methods).forEach(function(mName) {


### PR DESCRIPTION
After recent refactoring, url is resolved to `undefined`/api/path-to-query.  Here is the fix. 
I tried not to use latest apis like back-tics and object.assign to support legacy versions.

