### PR TITLE
Set version to 1.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graylog-api",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Node.js module for Graylog2 API",
   "author": {
     "name": "Andrii Kolomiichenko",


### PR DESCRIPTION
I noticed that on npmjs graylog-api is of version 1.2.0 just like here on github, but the code is not the same.

Here on github an issue with the url has been patched.
https://github.com/kolomiichenko/graylog-api/commit/0a1728f263e242f6de6f8d89300a2e23a74116e8

Let's bump the version number so it's visible that a patch has been done and it's not the same code as on npmjs.
It would be great if the patched code could be updated at npmjs as well.